### PR TITLE
Making CPANPLUS rebuilt its module tree faster (part 1)

### DIFF
--- a/lib/Object/Accessor.pm
+++ b/lib/Object/Accessor.pm
@@ -4,7 +4,6 @@ use strict;
 use Carp            qw[carp croak];
 use vars            qw[$FATAL $DEBUG $AUTOLOAD $VERSION];
 use Params::Check   qw[allow];
-use Data::Dumper;
 
 ### some objects might have overload enabled, we'll need to
 ### disable string overloading for callbacks
@@ -742,7 +741,6 @@ See C<perldoc perlsub> for details.
 ### standard tie class for bound attributes
 {   package Object::Accessor::TIE;
     use Tie::Scalar;
-    use Data::Dumper;
     use base 'Tie::StdScalar';
 
     my %local = ();

--- a/lib/Object/Accessor.pm
+++ b/lib/Object/Accessor.pm
@@ -432,18 +432,18 @@ sub can {
     ### it's one of our regular methods
     my $code = $self->UNIVERSAL::can($method);
     if( $code ) {
-        __PACKAGE__->___debug( "Can '$method' -- provided by package" );
+        carp( "Can '$method' -- provided by package" ) if $DEBUG;
         return $code;
     }
 
     ### it's an accessor we provide;
     if( UNIVERSAL::isa( $self, 'HASH' ) and exists $self->{$method} ) {
-        __PACKAGE__->___debug( "Can '$method' -- provided by object" );
+        carp( "Can '$method' -- provided by object" ) if $DEBUG;
         return sub { $self->$method(@_); }
     }
 
     ### we don't support it
-    __PACKAGE__->___debug( "Cannot '$method'" );
+    carp( "Cannot '$method'" ) if $DEBUG;
     return;
 }
 

--- a/lib/Object/Accessor.pm
+++ b/lib/Object/Accessor.pm
@@ -430,9 +430,10 @@ sub can {
     my($self, $method) = @_;
 
     ### it's one of our regular methods
-    if( $self->UNIVERSAL::can($method) ) {
+    my $code = $self->UNIVERSAL::can($method);
+    if( $code ) {
         __PACKAGE__->___debug( "Can '$method' -- provided by package" );
-        return $self->UNIVERSAL::can($method);
+        return $code;
     }
 
     ### it's an accessor we provide;

--- a/lib/Object/Accessor.pm
+++ b/lib/Object/Accessor.pm
@@ -611,7 +611,6 @@ sub ___debug {
 
     my $self = shift;
     my $msg  = shift;
-    my $lvl  = shift || 0;
 
     local $Carp::CarpLevel += 1;
 


### PR DESCRIPTION
These commits focus on making Object::Accessor::can() leaner, as Devel::NYTProf shows that it is called a lot when the module tree is rebuilt.

This pull request is best applied in conjunction with the two others that I sent for Params::Check and CPANPLUS, but all three are technically independent.

Vincent.
